### PR TITLE
Nexus 3 supports RubyGems and PyPI

### DIFF
--- a/src/docs/asciidoc/Binary-Repository-Manager-Feature-Matrix.adoc
+++ b/src/docs/asciidoc/Binary-Repository-Manager-Feature-Matrix.adoc
@@ -996,7 +996,7 @@ read only
 (Pro)
 |[green]*&#10004;* +
 (OSS) browsing, searching and custom metadata aren't supported
-|*?*
+|[green]*&#10004;*
 |[red]*&#10008;*
 |[red]*&#10008;*
 
@@ -1042,7 +1042,7 @@ With GPG signing
 |[green]*&#10004;* +
 (Pro)
 |[red]*&#10008;*
-|[red]*&#10008;*
+|[green]*&#10004;*
 |[red]*&#10008;*
 |[red]*&#10008;*
 


### PR DESCRIPTION
Sonatype Nexus 3 does support RubyGems and Python Eggs (PyPI) per their
documentation:

```
https://www.sonatype.com/download-oss-sonatype
https://books.sonatype.com/nexus-book/3.0/reference/index.html
```

Make both entries green with a check mark.
